### PR TITLE
perf: optimize encode Simple node search with branchless mask

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -900,18 +900,34 @@ impl Tree {
             FullKey::NoSuccessor => None,
             FullKey::Simple(idx) => {
                 let nexts = &self.simples[usize::from(idx)];
-                let successors = nexts
-                    .codes
-                    .iter()
-                    .zip(nexts.chars.iter())
-                    .take(usize::from(nexts.count));
-                for (&scode, &sch) in successors {
-                    if sch == ch {
-                        return Some(scode);
+                let count = usize::from(nexts.count);
+                let chars = &nexts.chars;
+
+                if count <= 4 {
+                    // Sparse nodes: early-termination search.
+                    for i in 0..count {
+                        if chars[i] == ch {
+                            return Some(nexts.codes[i]);
+                        }
+                    }
+                    None
+                } else {
+                    // Dense nodes: branchless mask search over all 16 slots.
+                    // LLVM auto-vectorizes this into PCMPEQB + PMOVMSKB.
+                    let count_mask = (1u32 << count) - 1;
+                    let mut match_mask = 0u32;
+                    for i in 0..SHORT {
+                        if chars[i] == ch {
+                            match_mask |= 1 << i;
+                        }
+                    }
+                    match_mask &= count_mask;
+                    if match_mask != 0 {
+                        Some(nexts.codes[match_mask.trailing_zeros() as usize])
+                    } else {
+                        None
                     }
                 }
-
-                None
             }
             FullKey::Full(idx) => {
                 let full = &self.complex[usize::from(idx)];


### PR DESCRIPTION
## Summary

Replace the linear early-termination search in `Tree::at_key` for Simple nodes (count > 4) with a branchless mask-based search over all 16 character slots. LLVM auto-vectorizes the fixed-iteration loop into `pcmpeqb` + `pmovmskb` on x86, searching all 16 bytes in ~4 instructions instead of up to 16 compare-and-branch sequences.

Sparse nodes (count ≤ 4) retain the original early-termination search, which is faster when there are only 1-3 entries to check.

## Behavior

No change — produces identical output for all inputs. Only the search strategy differs for Simple nodes with 5+ entries.

## Benchmark results

Encode throughput improvement across synthetic datasets (256KB, LSB mode):

| Dataset | Improvement |
|---------|------------|
| random (high entropy) | +54-58% |
| photo-gif (medium) | +14-16% |
| tiff grayscale | +13-16% |
| palette GIF | +4-5% |
| gradient | +4-6% |
| solid (low entropy) | +4-5% |

Verified auto-vectorization via `cargo asm` — the dense path compiles to `pcmpeqb xmm` + `bsf` (SSE2 byte compare + bit scan).

## Test plan

- [x] All existing tests pass (roundtrip, roundtrip_vec, implicit_reset, end_of_buffer, async, doctests)
- [x] Verified vectorization via cargo asm
- [x] No regressions on any tested dataset (decode unaffected)