### PR TITLE
test: regression for derive_burst OOB on bit-flipped input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,5 +93,9 @@ required-features = ["std"]
 name = "end_of_buffer"
 required-features = ["alloc"]
 
+[[test]]
+name = "fuzz_panic_regression"
+required-features = ["alloc"]
+
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/fuzz_panic_regression.rs
+++ b/tests/fuzz_panic_regression.rs
@@ -1,0 +1,94 @@
+//! Regression test for an out-of-bounds panic found via single-bit-flip
+//! mutation fuzzing of valid LZW streams at `min_code_size = 12`.
+//!
+//! Before the fixed-array decode table landed
+//! (https://github.com/image-rs/weezl/pull/61), a single bit flip in the
+//! encoded output of `b"Hello, world"` could steer `Table::derive_burst`
+//! into indexing its `depths` vector one past the end, panicking with:
+//!
+//!     index out of bounds: the len is 4098 but the index is 4098
+//!
+//! The `& MASK` indexing pattern introduced by #61 replaces the OOB with
+//! a wrapping read, so corrupt input now produces wrong output or a clean
+//! `LzwError::InvalidCode`, but must never panic.
+//!
+//! Test order is deliberate:
+//!
+//!   1. First collect the "min invariant": round-trip a set of valid
+//!      inputs and assert byte-identical output. This is the observable
+//!      consequence of the reconstruct chain walk's `entry.prev < len`
+//!      invariant — if any case mismatches, the decoder is broken on
+//!      valid data and the subsequent corrupt-input check would be
+//!      meaningless.
+//!
+//!   2. Only then feed the bit-flipped stream to the decoder. Both `Ok`
+//!      and `Err` are acceptable; simply returning from `decode()`
+//!      (rather than unwinding) is the property under test.
+
+use weezl::decode::Decoder;
+use weezl::encode::Encoder;
+use weezl::BitOrder;
+
+#[test]
+fn corrupt_input_does_not_panic_in_derive_burst() {
+    // --- Phase 1: min invariant — valid round-trips ---------------------
+    //
+    // A compact but deliberately diverse set: the exact literal whose
+    // encoding the fuzz flip targets, a zero run, an all-0xff run, a
+    // repeating alphabet, and a small byte ramp. Both bit orders, and a
+    // spread of code sizes including 12 (where the fuzz finding lived).
+    let inputs: &[(&str, &[u8])] = &[
+        ("hello_world", b"Hello, world"),
+        ("zero_run_4k", &[0u8; 4096]),
+        ("ff_run_4k", &[0xffu8; 4096]),
+        ("alphabet", b"abcdefghijklmnopqrstuvwxyz"),
+        ("ramp_256", &{
+            let mut r = [0u8; 256];
+            for (i, b) in r.iter_mut().enumerate() {
+                *b = i as u8;
+            }
+            r
+        }),
+    ];
+
+    for &order in &[BitOrder::Lsb, BitOrder::Msb] {
+        for &min_code_size in &[8u8, 9, 12] {
+            for (label, data) in inputs {
+                let encoded = Encoder::new(order, min_code_size)
+                    .encode(data)
+                    .unwrap_or_else(|e| {
+                        panic!("encode {} {:?}/{}: {:?}", label, order, min_code_size, e)
+                    });
+                let decoded = Decoder::new(order, min_code_size)
+                    .decode(&encoded)
+                    .unwrap_or_else(|e| {
+                        panic!("decode {} {:?}/{}: {:?}", label, order, min_code_size, e)
+                    });
+                assert_eq!(
+                    decoded, *data,
+                    "round-trip mismatch for {} at {:?}/{}",
+                    label, order, min_code_size
+                );
+            }
+        }
+    }
+
+    // --- Phase 2: corrupt input must not panic --------------------------
+    //
+    // Re-encode the literal the fuzz harness started from, then flip a
+    // single bit. The flip is byte index 3, bit 3 — the minimal mutation
+    // that historically panicked `derive_burst`. Both `Ok` and `Err` are
+    // acceptable outcomes; reaching this line without unwinding is the
+    // property under test.
+    let encoded = Encoder::new(BitOrder::Lsb, 12)
+        .encode(b"Hello, world")
+        .expect("encode baseline");
+    assert!(
+        encoded.len() > 3,
+        "encoded baseline too short to mutate at byte 3"
+    );
+    let mut corrupt = encoded.clone();
+    corrupt[3] ^= 0x08;
+
+    let _ = Decoder::new(BitOrder::Lsb, 12).decode(&corrupt);
+}


### PR DESCRIPTION
## Summary

Locks in an incidental fix from #61. Single-bit-flip mutation fuzzing of
a valid `min_code_size = 12` encoding of `b"Hello, world"` steered
`Table::derive_burst` into indexing its `depths` vector one past the
end, panicking with:

```
index out of bounds: the len is 4098 but the index is 4098
  at src/decode.rs:1474:36
```

The fixed-array decode table in #61 replaced that `Vec`-bounded lookup
with `& MASK` indexing, so the OOB became a wrapping read. Corrupt
input can still produce wrong output or an `LzwError::InvalidCode`, but
must never unwind. This adds a regression test so that property
doesn't silently disappear the next time the table is reworked.

## Test structure

The single test runs two phases in order — this is load-bearing:

1. **Min invariant.** Round-trip a small diverse set of valid inputs
   (the literal the fuzzer targeted, a zero run, an `0xff` run, an
   alphabet, a byte ramp) at both bit orders and at
   `min_code_size ∈ {8, 9, 12}`. This is the visible consequence of the
   reconstruct chain-walk `entry.prev < len` invariant — if any case
   mismatches, the decoder is broken on valid data and the
   corrupt-input check below is meaningless.

2. **Corrupt input must not panic.** Re-encode the baseline literal,
   flip `byte[3] bit 3`, and call `Decoder::decode()`. Both `Ok` and
   `Err` are acceptable; the property under test is simply that
   `decode()` returns instead of unwinding.

## Historical verification

Verified against three commits in \`master\`'s first-parent history:

| commit     | what it is                                            | result |
| ---------- | ----------------------------------------------------- | ------ |
| \`bb5cd04\` | \`Merge pull request #59\` — last master commit before #61 | **FAIL** (panic at \`src/decode.rs:1474:36\`) |
| \`95f1b1c\` | \`Merge pull request #61 from lilith/fixed-array-table\`   | PASS |
| \`c0985db\` | \`Merge pull request #63\` — current master HEAD           | PASS |

## Test plan

- [x] Passes on current \`master\` (\`c0985db\`)
- [x] Fails on pre-#61 master (\`bb5cd04\`) with the exact panic above
- [x] Full \`cargo test\` suite still green
- [x] \`cargo fmt --check\` clean