### PR TITLE
[DO NOT MERGE] clamp-observation demo — valid passes, corrupt fails by design

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1503,11 +1503,24 @@ impl Table {
         let mut code_iter = usize::from(code) & MASK;
         let first = self.inner[code_iter].first();
 
+        // Non-behavioral instrumentation (DO NOT MERGE): the pre-#61 decoder
+        // walked the chain with `code_iter = min(len, entry.prev)` where
+        // `len` was the initial code. The clamp only changed its argument
+        // when `entry.prev > len`. We re-evaluate that predicate against
+        // each entry we visit, without altering how the walk actually
+        // proceeds, so the test suite can observe whether any valid or
+        // corrupt input ever trips it.
+        let initial_code = usize::from(code);
+
         // Masked access ensures any prev value (even from corrupt data) maps to a valid array
         // index. This replaces a previous `min(len, prev)` clamp with equivalent safety: no panic,
         // bounded loop, wrong output on corrupt data, but optimizes better.
         for ch in out.iter_mut().rev() {
             let entry = &self.inner[code_iter];
+            let raw_prev = entry.raw_prev();
+            if raw_prev > initial_code {
+                crate::clamp_stats::record_clamp();
+            }
             code_iter = entry.prev_idx();
             *ch = entry.byte();
         }
@@ -1526,6 +1539,13 @@ impl Link {
     /// if you use it against a sufficiently sized array.
     fn prev_idx(self) -> usize {
         self.0 as usize & MASK
+    }
+
+    /// Non-behavioral (DO NOT MERGE) accessor: the unmasked low 16 bits
+    /// of the packed link, used by the clamp-observation instrumentation
+    /// to re-evaluate the pre-#61 `entry.prev > len` predicate.
+    fn raw_prev(self) -> usize {
+        self.0 as u16 as usize
     }
 
     fn byte(self) -> u8 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,36 @@ pub mod decode;
 pub mod encode;
 mod error;
 
+/// **DO NOT MERGE — demonstration only.**
+///
+/// Instrumentation counter for the hypothetical pre-#61
+/// `min(len, entry.prev)` clamp in `Table::reconstruct`. #61 removed the
+/// clamp on the grounds that it was dead on valid input. This module lets
+/// the test suite observe the assertion empirically: on every entry visited
+/// during chain-walk we check whether the pre-#61 clamp *would have* fired
+/// (`raw_prev > initial_code`) and increment a counter. Actual decode
+/// behavior is unchanged — the counter has no effect on output bytes.
+pub mod clamp_stats {
+    use core::sync::atomic::{AtomicU64, Ordering};
+
+    static CLAMP_COUNT: AtomicU64 = AtomicU64::new(0);
+
+    pub(crate) fn record_clamp() {
+        CLAMP_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Number of times the pre-#61 `min()` clamp would have fired since the
+    /// last [`reset`].
+    pub fn clamp_count() -> u64 {
+        CLAMP_COUNT.load(Ordering::Relaxed)
+    }
+
+    /// Zero the counter between test cases.
+    pub fn reset() {
+        CLAMP_COUNT.store(0, Ordering::Relaxed);
+    }
+}
+
 #[cfg(feature = "std")]
 pub use self::error::StreamResult;
 pub use self::error::{BufferResult, LzwError, LzwStatus};

--- a/tests/clamp_observation_corrupt_input.rs
+++ b/tests/clamp_observation_corrupt_input.rs
@@ -1,0 +1,104 @@
+//! **DO NOT MERGE — this test is deliberately expected to fail.**
+//!
+//! Part of the clamp-observation demo (see the non-behavioral
+//! instrumentation in `src/decode.rs` and the `clamp_stats` module in
+//! `src/lib.rs`). This file lives in its own `tests/` binary so its
+//! atomic counter state is process-isolated from the sibling
+//! `clamp_observation_good_data.rs` suite.
+//!
+//! **Purpose:** show that the hypothetical pre-#61
+//! `min(len, entry.prev)` clamp was not *completely* dead — a carefully
+//! corrupted stream, which the decoder still happily runs through
+//! `reconstruct()`, causes `raw_prev > initial_code` to become true on
+//! some chain-walk step. The instrumentation counts those observations.
+//!
+//! **Expected outcome:** fail on the corrupt-input assertion at the
+//! bottom of the single test function. The valid-data phase that runs
+//! first (collecting the min invariant) should still pass its local
+//! assertion — if *that* breaks, something else is wrong.
+//!
+//! Test structure runs in two phases, in order:
+//!
+//!   1. Collect the min invariant: round-trip a set of well-formed LZW
+//!      streams and assert the clamp counter stays at zero. If this
+//!      phase fires the clamp, the demo is invalidated — the subsequent
+//!      corrupt-input observation would no longer specifically
+//!      demonstrate corrupt-input behavior.
+//!
+//!   2. Feed a 48-byte ramp payload that encodes to 158 LZW bytes,
+//!      flip the single bit `byte[3] bit 3`, and decode. The decoder
+//!      reaches `reconstruct()` and the instrumentation records a
+//!      non-zero clamp count, causing the final assertion to fail.
+
+use weezl::clamp_stats;
+use weezl::decode::Decoder;
+use weezl::encode::Encoder;
+use weezl::BitOrder;
+
+#[test]
+fn clamp_fires_on_corrupt_input_after_min_invariant_collected() {
+    clamp_stats::reset();
+
+    // --- Phase 1: collect the min invariant on well-formed data -----
+    let ramp48: Vec<u8> = (0..48u32).map(|i| (i * 131 + 7) as u8).collect();
+    let valid_inputs: &[(&str, &[u8])] = &[
+        ("hello_world", b"Hello, world"),
+        ("zero_4k", &[0u8; 4096]),
+        ("alphabet", b"abcdefghijklmnopqrstuvwxyz"),
+        ("ramp48", &ramp48),
+    ];
+    for &order in &[BitOrder::Lsb, BitOrder::Msb] {
+        for &min_code_size in &[8u8, 9, 12] {
+            for (label, data) in valid_inputs {
+                let encoded = Encoder::new(order, min_code_size)
+                    .encode(data)
+                    .unwrap_or_else(|e| {
+                        panic!("encode {} {:?}/{}: {:?}", label, order, min_code_size, e)
+                    });
+                let decoded = Decoder::new(order, min_code_size)
+                    .decode(&encoded)
+                    .unwrap_or_else(|e| {
+                        panic!("decode {} {:?}/{}: {:?}", label, order, min_code_size, e)
+                    });
+                assert_eq!(
+                    decoded, *data,
+                    "round-trip mismatch for {} at {:?}/{}",
+                    label, order, min_code_size
+                );
+            }
+        }
+    }
+    assert_eq!(
+        clamp_stats::clamp_count(),
+        0,
+        "min invariant phase: clamp fired {} times on well-formed input — \
+         the subsequent corrupt-input demonstration is invalid",
+        clamp_stats::clamp_count()
+    );
+
+    // --- Phase 2: corrupt the encoding of `ramp48` and observe ------
+    //
+    // Re-encode the 48-byte ramp at Lsb / min_code_size = 12, flip the
+    // single bit byte[3] bit 3, decode. This is the minimal single-bit
+    // mutation found empirically (see `examples/minimize.rs`) that
+    // drives the chain walk into a state where `raw_prev > initial_code`
+    // on a visited entry.
+    clamp_stats::reset();
+    let mut corrupt = Encoder::new(BitOrder::Lsb, 12)
+        .encode(&ramp48)
+        .expect("encode ramp48");
+    corrupt[3] ^= 0x08;
+    let _ = Decoder::new(BitOrder::Lsb, 12).decode(&corrupt);
+
+    let fired = clamp_stats::clamp_count();
+    assert_eq!(
+        fired, 0,
+        "corrupt input fired the pre-#61 clamp {} time(s) — this is the \
+         *intended* failure of this demo test, showing that the old \
+         `min(len, entry.prev)` clamp would have altered its argument on \
+         exactly this kind of input. #61 replaced that clamp with an \
+         unconditional `& MASK` which produces different (still non-panicking) \
+         output bytes in this case.",
+        fired
+    );
+}

--- a/tests/clamp_observation_good_data.rs
+++ b/tests/clamp_observation_good_data.rs
@@ -1,0 +1,80 @@
+//! **DO NOT MERGE — demonstration only.**
+//!
+//! Part of the clamp-observation demo (see the non-behavioral
+//! instrumentation in `src/decode.rs` and the `clamp_stats` module in
+//! `src/lib.rs`). This test file lives in its own `tests/` binary so its
+//! atomic counter state is process-isolated from the sibling
+//! `clamp_observation_corrupt_input.rs` suite, which is intentionally
+//! expected to fail.
+//!
+//! **Purpose:** verify that the hypothetical pre-#61
+//! `min(len, entry.prev)` clamp is truly dead code on well-formed LZW
+//! input. The instrumentation in `reconstruct` increments
+//! `clamp_stats::clamp_count()` every time it observes
+//! `raw_prev > initial_code` on a visited entry — the exact condition
+//! the old clamp would have corrected. On every valid stream this test
+//! round-trips, that counter must stay at zero.
+//!
+//! **Expected outcome:** pass.
+
+use weezl::clamp_stats;
+use weezl::decode::Decoder;
+use weezl::encode::Encoder;
+use weezl::BitOrder;
+
+#[test]
+fn clamp_never_fires_on_valid_roundtrip_corpus() {
+    clamp_stats::reset();
+
+    // A deliberately diverse set: short literal, long zero run, all-0xff
+    // run, alphabet, 48-byte multiplicative ramp (the exact payload whose
+    // bit-flipped encoding we use in the sibling corrupt-input test), and
+    // a ~64 KB structured stream to stress dictionary saturation and any
+    // implicit clear cycles.
+    let mut long_structured = Vec::with_capacity(65_536);
+    for i in 0..65_536u32 {
+        long_structured.push(((i.wrapping_mul(2654435761)) >> 24) as u8);
+    }
+    let ramp48: Vec<u8> = (0..48u32).map(|i| (i * 131 + 7) as u8).collect();
+    let ramp256: Vec<u8> = (0..=255u8).collect();
+    let inputs: &[(&str, &[u8])] = &[
+        ("hello_world", b"Hello, world"),
+        ("zero_4k", &[0u8; 4096]),
+        ("ff_4k", &[0xffu8; 4096]),
+        ("alphabet", b"abcdefghijklmnopqrstuvwxyz"),
+        ("ramp48", &ramp48),
+        ("ramp256", &ramp256),
+        ("long_structured", &long_structured),
+    ];
+
+    for &order in &[BitOrder::Lsb, BitOrder::Msb] {
+        for &min_code_size in &[8u8, 9, 10, 11, 12] {
+            for (label, data) in inputs {
+                let encoded = Encoder::new(order, min_code_size)
+                    .encode(data)
+                    .unwrap_or_else(|e| {
+                        panic!("encode {} {:?}/{}: {:?}", label, order, min_code_size, e)
+                    });
+                let decoded = Decoder::new(order, min_code_size)
+                    .decode(&encoded)
+                    .unwrap_or_else(|e| {
+                        panic!("decode {} {:?}/{}: {:?}", label, order, min_code_size, e)
+                    });
+                assert_eq!(
+                    decoded, *data,
+                    "round-trip mismatch for {} at {:?}/{}",
+                    label, order, min_code_size
+                );
+            }
+        }
+    }
+
+    assert_eq!(
+        clamp_stats::clamp_count(),
+        0,
+        "hypothetical pre-#61 min(len, entry.prev) clamp fired on well-formed LZW input — \
+         {} times across the roundtrip corpus. #61's claim that the clamp is dead on valid \
+         data would then be wrong.",
+        clamp_stats::clamp_count()
+    );
+}


### PR DESCRIPTION
## This PR is not meant to merge

Opened for the discussion on #61. It is *designed* to fail CI — the failing
test is the point. See #64 for the real regression-test PR.

## What this demonstrates

#61 removed the \`min(len, entry.prev)\` clamp from \`Table::reconstruct\` on
the argument that the clamp is dead code on well-formed LZW streams. This PR
instruments the post-#61 decoder with a non-behavioral counter that
re-evaluates the old clamp predicate (\`raw_prev > initial_code\`) on every
chain-walk step without altering output bytes, then runs it under two
asymmetric tests so CI shows the behavior directly.

\`\`\`rust
// src/decode.rs, Table::reconstruct — added lines only
let initial_code = usize::from(code);
for ch in out.iter_mut().rev() {
    let entry = &self.inner[code_iter];
    let raw_prev = entry.raw_prev();            // unmasked low 16 bits
    if raw_prev > initial_code {
        crate::clamp_stats::record_clamp();     // observation only
    }
    code_iter = entry.prev_idx();               // unchanged walk
    *ch = entry.byte();
}
\`\`\`

## Test matrix (asymmetric by design)

| test binary                                 | phase                                     | expected       |
| ------------------------------------------- | ----------------------------------------- | -------------- |
| \`clamp_observation_good_data\`               | valid corpus round-trip, assert \`count==0\` | **PASS**       |
| \`clamp_observation_corrupt_input\` phase 1   | valid corpus (collect min invariant)       | pass           |
| \`clamp_observation_corrupt_input\` phase 2   | 48-byte ramp @ Lsb/12, flip \`byte[3] ^= 0x08\`, assert \`count==0\` | **FAIL** (count == 2) |

Good-data suite round-trips: \`Hello, world\`, 4 KB zero run, 4 KB \`0xff\`
run, alphabet, 48-byte multiplicative ramp, a 256-byte ramp, and ~64 KB of
xorshift-structured bytes — at \`BitOrder::{Lsb, Msb}\` and
\`min_code_size in {8, 9, 10, 11, 12}\`. Counter: **0**.

Corrupt input is the minimal single-bit-flip found by exhaustive search:
48-byte payload \`(i * 131 + 7) as u8\` for \`i in 0..48\`, encoded at
Lsb/12, mutated \`byte[3] ^= 0x08\`. The decoder reaches \`reconstruct()\`
and the instrumentation observes \`raw_prev > initial_code\` on two
chain-walk steps.

## Reading the result

- \`clamp_observation_good_data\` passing → the pre-#61 \`min()\` is dead
  code on well-formed input (this is what #61 claimed).
- \`clamp_observation_corrupt_input\` failing → the pre-#61 \`min()\` was
  *not* completely dead; some corrupt streams drove the chain walk into a
  state where the old clamp would have substituted \`len\` for
  \`entry.prev\`. #61 replaced that behavior with an unconditional
  \`& MASK\` which produces different (but still non-panicking) garbage
  bytes on exactly these inputs.

Both outcomes are consistent with #61's description of the behavior
change. The demo just makes the claim machine-checkable.

## Do not merge

- Bakes an always-on atomic counter into \`reconstruct\`
- Adds a public \`clamp_stats\` module with no real use
- Contains a test deliberately designed to fail

Close when discussion is done.