### PR TITLE
fix: yield_on_full correctness on wuffs branch (#68)

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -905,22 +905,32 @@ impl<C: CodeBuffer, CgC: CodegenConstants> Stateful for DecodeState<C, CgC> {
         // Track an empty `burst` (see below) means we made no progress.
         let mut have_yet_to_decode_data = false;
 
-        // Restore the previous state, if any.
-        if code_link.is_some() {
+        // Drain the internal buffer unconditionally. Data lands here when
+        // a decoded code was longer than the caller's output buffer, or
+        // after a clear code that interrupted mid-stream. Must not be
+        // gated on code_link.is_some() — that skips the drain after a
+        // clear code sets code_link=None, losing buffered data (#68).
+        {
             let remain = self.buffer.buffer();
-            // Check if we can fully finish the buffer.
             if remain.len() > out.len() {
                 if out.is_empty() {
-                    // This also implies the buffer is _not_ empty and we will not enter any
-                    // decoding loop.
-                    status = Ok(LzwStatus::NoProgress);
+                    if remain.is_empty() {
+                        // Truly nothing — no buffer data, no output space.
+                        status = Ok(LzwStatus::NoProgress);
+                        have_yet_to_decode_data = true;
+                    } else {
+                        // Buffer has data but caller gave empty output.
+                        status = Ok(LzwStatus::NoProgress);
+                    }
                 } else {
                     out.copy_from_slice(&remain[..out.len()]);
                     self.buffer.consume(out.len());
                     out = &mut [];
                 }
             } else if remain.is_empty() {
-                status = Ok(LzwStatus::NoProgress);
+                if code_link.is_none() {
+                    status = Ok(LzwStatus::NoProgress);
+                }
                 have_yet_to_decode_data = true;
             } else {
                 let consumed = remain.len();
@@ -1088,11 +1098,19 @@ impl<C: CodeBuffer, CgC: CodegenConstants> Stateful for DecodeState<C, CgC> {
                         // code we use unaligned 64-bit stores regardless of code depth. This
                         // requires us to have more buffer space than required but that is almost
                         // always the case until we get to the end.
+                        //
+                        // The overwrite may clobber up to 7 bytes past the code length. Those
+                        // bytes must be within the output buffer and must be overwritten by
+                        // subsequent codes before the caller reads them. With yield_on_full or
+                        // small buffers, the decoder may return before that happens. Require at
+                        // least 8 bytes of slack past the code length to ensure the clobbered
+                        // bytes stay in uncommitted territory.
                         let chunk_len = len.div_ceil(8);
+                        let slack = out.len() - usize::from(len);
                         let chunked = out.as_chunks_mut::<8>().0;
 
                         let target;
-                        if chunked.len() >= usize::from(chunk_len) {
+                        if chunked.len() >= usize::from(chunk_len) && slack >= 8 {
                             let relaxed = &mut chunked[..usize::from(chunk_len)];
                             burst_byte[burst_size - 1] =
                                 self.table.reconstruct_simple(read_code, relaxed);
@@ -1116,7 +1134,7 @@ impl<C: CodeBuffer, CgC: CodegenConstants> Stateful for DecodeState<C, CgC> {
                         self.table.derive_burst(&mut deriv, codes, &burst_byte[..]);
                     }
 
-                    debug_assert!(self.next_code <= size_switch_at);
+                    debug_assert!(self.table.is_full() || self.next_code <= size_switch_at);
                     code_link = Some(DerivationBase {
                         code: burst[cnt - 1],
                         first: burst_byte[cnt - 1],

--- a/tests/yield_on_full_regression.rs
+++ b/tests/yield_on_full_regression.rs
@@ -1,0 +1,139 @@
+//! Regression tests for yield_on_full_buffer correctness (issue #68).
+//!
+//! The decoder's yield_on_full mode is used for libtiff compatibility:
+//! the caller provides a fixed-size output buffer and expects the decoder
+//! to return when it's full, allowing incremental processing. When the
+//! decoder yields mid-stream and resumes, the output must match a
+//! straight decode without yield_on_full.
+//!
+//! These tests encode data → decode with yield_on_full using small
+//! output buffers → compare to the original input. Any divergence is
+//! a correctness bug.
+
+use weezl::{decode::Configuration, encode, BitOrder, LzwStatus};
+
+/// Decode with yield_on_full using a fixed-size output buffer,
+/// collecting all output into a Vec.
+fn decode_yield(encoded: &[u8], order: BitOrder, size: u8, tiff: bool, buf_size: usize) -> Vec<u8> {
+    let config = if tiff {
+        Configuration::with_tiff_size_switch(order, size)
+    } else {
+        Configuration::new(order, size)
+    };
+    let mut dec = config.with_yield_on_full_buffer(true).build();
+
+    let mut result = Vec::new();
+    let mut inp = encoded;
+    let mut tmp = vec![0u8; buf_size];
+
+    loop {
+        let r = dec.decode_bytes(inp, &mut tmp);
+        inp = &inp[r.consumed_in..];
+        result.extend_from_slice(&tmp[..r.consumed_out]);
+        match r.status {
+            Ok(LzwStatus::Done) => return result,
+            Ok(LzwStatus::NoProgress) => {
+                if r.consumed_in == 0 && r.consumed_out == 0 {
+                    return result;
+                }
+            }
+            Ok(LzwStatus::Ok) => {}
+            Err(e) => panic!("decode error: {:?}", e),
+        }
+        if result.len() > 1 << 22 {
+            panic!("output too large");
+        }
+    }
+}
+
+/// Decode without yield_on_full (straight decode) as reference.
+fn decode_straight(encoded: &[u8], order: BitOrder, size: u8, tiff: bool) -> Vec<u8> {
+    let mut dec = if tiff {
+        weezl::decode::Decoder::with_tiff_size_switch(order, size)
+    } else {
+        weezl::decode::Decoder::new(order, size)
+    };
+    dec.decode(encoded).expect("straight decode failed")
+}
+
+fn encode_data(data: &[u8], order: BitOrder, size: u8, tiff: bool) -> Vec<u8> {
+    let mut enc = if tiff {
+        encode::Encoder::with_tiff_size_switch(order, size)
+    } else {
+        encode::Encoder::new(order, size)
+    };
+    enc.encode(data).expect("encode failed")
+}
+
+/// Assert that yield_on_full decode matches straight decode matches
+/// the original input.
+fn assert_yield_roundtrip(data: &[u8], order: BitOrder, size: u8, tiff: bool, buf_size: usize) {
+    let encoded = encode_data(data, order, size, tiff);
+    let reference = decode_straight(&encoded, order, size, tiff);
+    let yielded = decode_yield(&encoded, order, size, tiff, buf_size);
+
+    assert_eq!(
+        data,
+        &reference[..],
+        "straight decode roundtrip mismatch (size={size} tiff={tiff} buf={buf_size})"
+    );
+    assert_eq!(
+        reference,
+        yielded,
+        "yield_on_full diverges from straight decode \
+         (size={size} order={order:?} tiff={tiff} buf={buf_size})\n\
+         reference len={}, yielded len={}",
+        reference.len(),
+        yielded.len()
+    );
+}
+
+// Fuzz-minimized reproducer: size=7, MSB, non-TIFF, yield_on_full=true.
+// Repeating 0x4A with 0x7F runs. The decoder loses bytes 99-108 when
+// yielding — they contain stale 0x7F values instead of 0x4A.
+#[test]
+fn regression_yield_on_full_fuzz_crash() {
+    let payload: &[u8] = &[
+        126, 36, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74,
+        74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 126, 44, 74, 74, 74, 74, 74, 74, 74, 74, 74,
+        127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+        127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+        127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74,
+        74, 74, 74, 74, 74, 74, 74, 74, 74, 126, 44,
+    ];
+    assert_yield_roundtrip(payload, BitOrder::Msb, 7, false, 8192);
+}
+
+#[test]
+fn regression_yield_on_full_small_buffers() {
+    let payload: &[u8] = &[
+        126, 36, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74,
+        74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74, 126, 44, 74, 74, 74, 74, 74, 74, 74, 74, 74,
+        127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+        127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+        127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 74, 74, 74, 74, 74, 74, 74, 74, 74, 74,
+        74, 74, 74, 74, 74, 74, 74, 74, 74, 126, 44,
+    ];
+    for buf_size in [1, 3, 7, 8, 9, 13, 15, 16, 17, 32, 64] {
+        assert_yield_roundtrip(payload, BitOrder::Msb, 7, false, buf_size);
+    }
+}
+
+#[test]
+fn yield_on_full_sweep_sizes() {
+    // The bug is not specific to one code size. Test yield_on_full
+    // roundtrip across all code sizes with data that triggers long codes.
+    for size in 2..=12u8 {
+        let mask = if size >= 8 {
+            0xFF
+        } else {
+            (1u16 << size) as u8 - 1
+        };
+        let data: Vec<u8> = (0u16..256).map(|i| (i as u8) & mask).collect();
+        for buf_size in [1, 7, 8, 9, 16, 64, 256] {
+            assert_yield_roundtrip(&data, BitOrder::Msb, size, false, buf_size);
+            assert_yield_roundtrip(&data, BitOrder::Lsb, size, false, buf_size);
+            assert_yield_roundtrip(&data, BitOrder::Msb, size, true, buf_size);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes for yield_on_full correctness on the `wuffs` branch, plus regression tests.

### Fixes

1. **Unconditional buffer drain (#68)**: The buffer drain at the start of `advance()` was gated on `code_link.is_some()`. After a clear code sets `code_link = None`, buffered data was silently lost. Same root cause as on `master`, same fix (PR #71).

2. **debug_assert in non-broken-burst path**: `debug_assert!(self.next_code <= size_switch_at)` fires in TIFF mode when the table is full (`next_code` = 4096 exceeds `size_switch_at` = 4094). Guard: `self.table.is_full() || ...`.

3. **reconstruct_simple overwrite guard**: The relaxed 8-byte-chunk overwrite can clobber bytes past the code length. With `yield_on_full` or tight buffers, those bytes may be returned to the caller before subsequent codes overwrite them. Guard: require >= 8 bytes of slack past the code length.

### Regression tests

Three tests in `tests/yield_on_full_regression.rs`:
- `regression_yield_on_full_fuzz_crash`: minimized fuzz input (size=7, MSB)
- `regression_yield_on_full_small_buffers`: buffer sizes 1-64
- `yield_on_full_sweep_sizes`: all code sizes 2-12

### Status

Fixes 1 and 2 pass. Fix 3 resolves the overwrite concern but **`small_buffers` with `buf=1` still fails** — the inline burst reconstruction has a separate data-loss path when `yield_on_full` causes mid-burst returns. The burst loop writes directly into `out` during validation, and when the burst breaks mid-way, some of that written data may not be properly accounted for. This needs further investigation specific to the wuffs burst loop restructuring.

## Test plan

- [x] `regression_yield_on_full_fuzz_crash` passes
- [x] `yield_on_full_sweep_sizes` passes
- [ ] `regression_yield_on_full_small_buffers` (buf=1) — still fails, needs separate fix
- [x] All pre-existing tests pass (14 unit + 4 roundtrip + 2 roundtrip_vec + 19 streaming_parity)